### PR TITLE
feat: add numeric log level for better sorting

### DIFF
--- a/Classes/Log/LogRecordFormatter.php
+++ b/Classes/Log/LogRecordFormatter.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Jops\TYPO3\Loki\Log;
+
+use TYPO3\CMS\Core\Log\LogLevel;
+use TYPO3\CMS\Core\Log\LogRecord;
+
+class LogRecordFormatter
+{
+    /**
+     * Format the given LogRecord as an array.
+     *
+     * This uses LogRecord::toArray internally but adds some additional fields.
+     */
+    public static function toArray(LogRecord $logRecord): array
+    {
+        return array_merge($logRecord->toArray(), [
+            "numeric_level" => LogLevel::normalizeLevel($logRecord->getLevel()),
+        ]);
+    }
+}

--- a/Classes/Log/Writers/JsonWriter.php
+++ b/Classes/Log/Writers/JsonWriter.php
@@ -2,6 +2,7 @@
 
 namespace Jops\TYPO3\Loki\Log\Writers;
 
+use Jops\TYPO3\Loki\Log\LogRecordFormatter;
 use Throwable;
 use RuntimeException;
 use TYPO3\CMS\Core\Log\LogRecord;
@@ -11,7 +12,7 @@ class JsonWriter extends FileWriter
 {
     public function writeLog(LogRecord $record): self
     {
-        $message = json_encode($record->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $message = json_encode(LogRecordFormatter::toArray($record), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
 
         if (false === fwrite(self::$logFileHandles[$this->logFile], $message . LF)) {
             throw new RuntimeException('Could not write log record to log file', 1345036335);

--- a/Classes/Log/Writers/LokiWriter.php
+++ b/Classes/Log/Writers/LokiWriter.php
@@ -2,6 +2,7 @@
 
 namespace Jops\TYPO3\Loki\Log\Writers;
 
+use Jops\TYPO3\Loki\Log\LogRecordFormatter;
 use RuntimeException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Http\RequestFactory;
@@ -48,9 +49,9 @@ class LokiWriter extends AbstractWriter
                 [
                     // Those are the labels we can query after
                     "stream" => $this->labels,
-                    // This is "unix epoch in nano seconds" and the log line string
+                    // This is "unix epoch in nanoseconds" and the log line string
                     "values" => [
-                        [ $this->unixEpochNanoSeconds(), json_encode($record->toArray())],
+                        [ $this->unixEpochNanoSeconds(), json_encode(LogRecordFormatter::toArray($record))],
                     ],
                 ],
             ],


### PR DESCRIPTION
This adds the normalized, numeric log level to the final log string.

This allows for better filtering and sorting in loki when you e.g. want to filter by multiple log levels.